### PR TITLE
Uxly 101/display streams immediately

### DIFF
--- a/src/Components/StreamsPage/Streams.tsx
+++ b/src/Components/StreamsPage/Streams.tsx
@@ -12,6 +12,7 @@ import TransactionDrawer from './TransactionDrawer';
 import Search from './Search';
 import { Typography } from '@mui/material';
 import axios from 'axios';
+import defaultdata from './defaultdata.json';
 
 const consoleLog = async () => {
   console.log('Searching!');
@@ -22,6 +23,26 @@ const Streams: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
+    const fetchData = async () => {
+      try {
+        // Fetch last 25 transactions
+        const response = await axios.get('https://uxly-analytics-717cfb342dbd.herokuapp.com/previous-stream-transactions');
+        const last25Transactions = response.data;
+        // Set the last 25 transactions as initial data
+        setRawD(last25Transactions);
+        setLoading(false);
+      } catch (error) {
+        // use default data if backend didn't fetch 25 transactions
+        console.error('Failed to fetch data:', error);
+        const defaultData = defaultdata;
+        console.log(defaultData);
+        setRawD(defaultData);
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+
     const socket = io('wss://uxly-analytics-717cfb342dbd.herokuapp.com', {
       transports: ['websocket'],
     });
@@ -38,6 +59,7 @@ const Streams: React.FC = () => {
       console.log(`Socket connected: ${socket.id}`);
     });
 
+    
     socket.on('USDT', (dataString) => {
       try {
         let data = [...dataString];
@@ -92,7 +114,7 @@ const Streams: React.FC = () => {
       console.log('Socket disconnected');
     };
   }, []); // The empty dependency array ensures the effect runs only once on mount
-
+  console.log('this is rawD', rawD);
   return (
     <div>
       <div className="app-container">

--- a/src/Components/StreamsPage/Streams.tsx
+++ b/src/Components/StreamsPage/Streams.tsx
@@ -59,7 +59,6 @@ const Streams: React.FC = () => {
       console.log(`Socket connected: ${socket.id}`);
     });
 
-    
     socket.on('USDT', (dataString) => {
       try {
         let data = [...dataString];
@@ -114,7 +113,6 @@ const Streams: React.FC = () => {
       console.log('Socket disconnected');
     };
   }, []); // The empty dependency array ensures the effect runs only once on mount
-  console.log('this is rawD', rawD);
   return (
     <div>
       <div className="app-container">

--- a/src/Components/StreamsPage/defaultdata.json
+++ b/src/Components/StreamsPage/defaultdata.json
@@ -1,0 +1,177 @@
+[
+  {
+    "totalValue": 468503.7836270001,
+    "averageValue": 14197.084352333337,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466700
+  },
+  {
+    "totalValue": 217877.072909,
+    "averageValue": 12816.298406411765,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466701
+  },
+  {
+    "totalValue": 112150.94955399999,
+    "averageValue": 8626.99611953846,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466702
+  },
+  {
+    "totalValue": 65915.273937,
+    "averageValue": 5070.405687461539,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466703
+  },
+  {
+    "totalValue": 96197.54498499999,
+    "averageValue": 6012.346561562499,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466704
+  },
+  {
+    "totalValue": 9093617.270534003,
+    "averageValue": 413346.2395697274,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466705
+  },
+  {
+    "totalValue": 118939.72492600001,
+    "averageValue": 5946.986246300001,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466706
+  },
+  {
+    "totalValue": 641619.00266,
+    "averageValue": 35645.50014777778,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466707
+  },
+  {
+    "totalValue": 1176090.3823330002,
+    "averageValue": 47043.61529332001,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466708
+  },
+  {
+    "totalValue": 139573.28971000004,
+    "averageValue": 4229.493627575759,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466709
+  },
+  {
+    "totalValue": 788741.48283,
+    "averageValue": 43818.971268333335,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466710
+  },
+  {
+    "totalValue": 55973.912289,
+    "averageValue": 2152.8427803461536,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466711
+  },
+  {
+    "totalValue": 2482.82333,
+    "averageValue": 620.7058325,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466712
+  },
+  {
+    "totalValue": 2619576.376105999,
+    "averageValue": 77046.36400311762,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466713
+  },
+  {
+    "totalValue": 1634723.9499599999,
+    "averageValue": 102170.24687249999,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466714
+  },
+  {
+    "totalValue": 128869.373744,
+    "averageValue": 5369.557239333333,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466715
+  },
+  {
+    "totalValue": 487784.572788,
+    "averageValue": 23227.836799428573,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466716
+  },
+  {
+    "totalValue": 174824.021446,
+    "averageValue": 17482.4021446,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466717
+  },
+  {
+    "totalValue": 137308.31829899998,
+    "averageValue": 10562.178330692306,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466718
+  },
+  {
+    "totalValue": 113277.28574200001,
+    "averageValue": 8713.63736476923,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466719
+  },
+  {
+    "totalValue": 432889.07753499993,
+    "averageValue": 14429.635917833331,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466720
+  },
+  {
+    "totalValue": 597845.0093149999,
+    "averageValue": 17081.28598042857,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466721
+  },
+  {
+    "totalValue": 2828524.582991001,
+    "averageValue": 157140.25461061118,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466722
+  },
+  {
+    "totalValue": 94018.63122899999,
+    "averageValue": 4700.931561449999,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466723
+  },
+  {
+    "totalValue": 1982966.5466160001,
+    "averageValue": 58322.54548870589,
+    "tokenName": "Tether USD",
+    "tokenSymbol": "USDT",
+    "blockNumber": 19466726
+  }
+]


### PR DESCRIPTION
Streams graph now renders immediately, either with default data I added in a json or, if the backend endpoint is implemented properly, then the last 25 transactions.